### PR TITLE
feat: 시작화면 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
 import './App.css'
 import { BrowserRouter, Route, Routes } from 'react-router'
-import Home from './pages/Home'
+import Home from './pages/Home.tsx'
+import OnBoarding from './pages/OnBoarding.tsx'
+import Todos from './pages/Todos.tsx'
+import TodosFind from './pages/TodosFind.tsx'
 
 function App() {
   return (
@@ -8,6 +11,9 @@ function App() {
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Home />} />
+          <Route path="/onboarding" element={<OnBoarding />} />
+          <Route path="/todos" element={<Todos />} />
+          <Route path="/todos/find" element={<TodosFind />} />
         </Routes>
       </BrowserRouter>
     </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,44 @@
-import React from 'react'
+import { useEffect, useState } from 'react'
+import { Link, useNavigate } from 'react-router'
+
+interface MockData {
+  isFirstVisit: boolean
+  hasTodoData: boolean
+}
+
+const mockData: MockData = {
+  isFirstVisit: false,
+  hasTodoData: false,
+}
 
 const Home = () => {
-  return <div>시작화면</div>
+  const navigate = useNavigate()
+  const [isFirstVisit, setIsFirstVisit] = useState(mockData.isFirstVisit)
+  const [hasTodoData, setHasTodoData] = useState(mockData.hasTodoData)
+
+  // 처음 접속하지 않았을 때
+  useEffect(() => {
+    if (!isFirstVisit) {
+      // 오늘 할일이 있다면
+      if (hasTodoData) {
+        navigate('/todos')
+        // 오늘 할일이 없다면
+      } else {
+        navigate('/todos/find')
+      }
+    }
+  }, [isFirstVisit, hasTodoData])
+
+  return (
+    <div>
+      <div>틈새시간 할일 알려줌</div>
+      <div>티끌,먼지 이미지</div>
+      {/* 시작하기 버튼 누르면 온보딩 화면으로 이동 */}
+      <Link to="/onboarding">
+        <button>시작하기</button>
+      </Link>
+    </div>
+  )
 }
 
 export default Home

--- a/src/pages/OnBoarding.tsx
+++ b/src/pages/OnBoarding.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const OnBoarding = () => {
+  return <div>OnBoarding</div>
+}
+
+export default OnBoarding

--- a/src/pages/Todos.tsx
+++ b/src/pages/Todos.tsx
@@ -1,0 +1,5 @@
+const Todos = () => {
+  return <div>할일 목록 페이지입니다.</div>
+}
+
+export default Todos

--- a/src/pages/TodosFind.tsx
+++ b/src/pages/TodosFind.tsx
@@ -1,0 +1,5 @@
+const TodosFind = () => {
+  return <div>할일 찾기 페이지입니다.</div>
+}
+
+export default TodosFind


### PR DESCRIPTION
# 제목
feat: 시작화면 페이지 구현
## 내용
- [x] 처음 접속했을 때 시작하기 버튼 클릭 시 온보딩 화면 이동
- [x] 처음 접속하지 않았을 때 오늘 할일이 있을 시 할일 목록 화면 이동
- [x] 처음 접속하지 않았을 때 오늘 할일이 없을 시 할일 찾기 화면 이동
