### PR TITLE
[feature] feat:  타이포 그래피 설정, 폰트 통합, 피그마 이름 그대로  컬러 theme설정 #60

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,41 @@
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
+  font-family: Pretandard, system-ui, Avenir, Helvetica, Arial, sans-serif;
 
   color-scheme: light dark;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+@font-face {
+  font-family: 'S-CoreDream-5Medium';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_six@1.2/S-CoreDream-5Medium.woff')
+    format('woff');
+  font-weight: 500;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'S-CoreDream-6Bold';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_six@1.2/S-CoreDream-6Bold.woff')
+    format('woff');
+  font-weight: 600;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'S-CoreDream-8Heavy';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_six@1.2/S-CoreDream-8Heavy.woff')
+    format('woff');
+  font-weight: 800;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'S-CoreDream-7ExtraBold';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_six@1.2/S-CoreDream-7ExtraBold.woff')
+    format('woff');
+  font-weight: 700;
+  font-style: normal;
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,55 +1,191 @@
 import { createTheme } from '@mui/material/styles'
+
 import tokens from './assets/tokens.json'
+
+import React from 'react'
 
 export const TickleyTheme = createTheme({
   palette: {
-    primary: {
-      main: tokens.color.pri100.value,
-      light: tokens.color.pri500.value,
-      dark: tokens.color.pri900.value,
-    },
-    grey: {
-      100: tokens.color.gray100.value,
-      200: tokens.color.gray200.value,
-      300: tokens.color.gray300.value,
-      400: tokens.color.gray400.value,
-      600: tokens.color.gray600.value,
-      700: tokens.color.gray700.value,
-      800: tokens.color.gray800.value,
-      900: tokens.color.gray900.value,
+    primary100: tokens.color.pri100.value,
+    primary500: tokens.color.pri500.value,
+    primary900: tokens.color.pri900.value,
+
+    gray100: tokens.color.gray100.value,
+    gray200: tokens.color.gray200.value,
+    gray300: tokens.color.gray300.value,
+    gray400: tokens.color.gray400.value,
+    gray600: tokens.color.gray600.value,
+    gray700: tokens.color.gray700.value,
+    gray800: tokens.color.gray800.value,
+    gray900: tokens.color.gray900.value,
+    gray1000: tokens.color.gray1000.value,
+
+    semanticRed: '#F24822',
+    semanticPurple1: '#5B67BA',
+    semanticGreen: '#009951',
+    semanticGreen1: '#D6F2CC',
+    semanticGreen2: '#B2DDA2',
+    semanticGreen3: '#7BB766',
+    semanticGreen4: '#367A1E',
+  },
+
+  typography: {
+    fontFamily: '"S-CoreDream", Arial, sans-serif',
+
+    'headline-8-heavy': {
+      fontWeight: 800,
+
+      fontSize: '48px',
     },
 
-    common: {
-      black: tokens.color.gray1000.value,
+    'headline-5-medium': {
+      fontWeight: 500,
+
+      fontSize: '66px',
+    },
+
+    'title-6-bold-34': {
+      fontWeight: 600,
+
+      fontSize: '34px',
+    },
+
+    'title-5-medium-26': {
+      fontWeight: 500,
+
+      fontSize: '26px',
+    },
+
+    'title-7-extrabold-20': {
+      fontWeight: 700,
+
+      fontSize: '20px',
+    },
+
+    'title-5-medium-18': {
+      fontWeight: 500,
+
+      fontSize: '18px',
+    },
+
+    'title-5-medium-16': {
+      fontWeight: 500,
+
+      fontSize: '16px',
+    },
+
+    'title-5-medium-12': {
+      fontWeight: 500,
+
+      fontSize: '12px',
     },
   },
-  typography: {
-    fontFamily: `'Pretendard', 'Arial', sans-serif`,
-  },
 })
+
 //TODO: 타입 정의 파일로 옮기기
+
 declare module '@mui/material/styles' {
   interface Palette {
-    semantic: {
-      green1: string
-      green2: string
-      green3: string
-      green4: string
-      red: string
-      purple1: string
-      green: string
-    }
+    primary100: string
+    primary500: string
+    primary900: string
+    gray100: string
+    gray200: string
+    gray300: string
+    gray400: string
+    gray600: string
+    gray700: string
+    gray800: string
+    gray900: string
+    gray1000: string
+
+    semanticGreen1: string
+    semanticGreen2: string
+    semanticGreen3: string
+    semanticGreen4: string
+    semanticRed: string
+    semanticPurple1: string
+    semanticGreen: string
   }
 
   interface PaletteOptions {
-    semantic?: {
-      green1: string
-      green2: string
-      green3: string
-      green4: string
-      red: string
-      purple1: string
-      green: string
-    }
+    primary100: string
+    primary500: string
+    primary900: string
+    gray100: string
+    gray200: string
+    gray300: string
+    gray400: string
+    gray600: string
+    gray700: string
+    gray800: string
+    gray900: string
+    gray1000: string
+
+    semanticGreen1: string
+    semanticGreen2: string
+    semanticGreen3: string
+    semanticGreen4: string
+    semanticRed: string
+    semanticPurple1: string
+    semanticGreen: string
+  }
+}
+
+declare module '@mui/material/Typography' {
+  interface TypographyPropsVariantOverrides {
+    'headline-5-medium': true
+
+    'headline-8-heavy': true
+
+    'title-6-bold-34': true
+
+    'title-5-medium-26': true
+
+    'title-7-extrabold-20': true
+
+    'title-5-medium-18': true
+
+    'title-5-medium-16': true
+
+    'title-5-medium-12': true
+  }
+}
+
+declare module '@mui/material/styles' {
+  interface TypographyVariants {
+    'headline-5-medium': React.CSSProperties
+
+    'headline-8-heavy': React.CSSProperties
+
+    'title-6-bold-34': React.CSSProperties
+
+    'title-5-medium-26': React.CSSProperties
+
+    'title-7-extrabold-20': React.CSSProperties
+
+    'title-5-medium-18': React.CSSProperties
+
+    'title-5-medium-16': React.CSSProperties
+
+    'title-5-medium-12': React.CSSProperties
+  }
+
+  interface TypographyVariantsOptions {
+    'headline-5-medium'?: React.CSSProperties
+
+    'headline-8-heavy'?: React.CSSProperties
+
+    'title-6-bold-34'?: React.CSSProperties
+
+    'title-5-medium-26'?: React.CSSProperties
+
+    'title-7-extrabold-20'?: React.CSSProperties
+
+    'title-5-medium-18'?: React.CSSProperties
+
+    'title-5-medium-16'?: React.CSSProperties
+
+    'title-5-medium-12'?: React.CSSProperties
   }
 }


### PR DESCRIPTION
# 제목 
피그마에 적용된 이름 그대로 팀원들이 사용할 수 있게 MaterialUI theme 적용
## 내용
- [x]  #60  완료 

